### PR TITLE
Dont use deprecated classes

### DIFF
--- a/etl_framework/BaseExtractor.py
+++ b/etl_framework/BaseExtractor.py
@@ -1,4 +1,8 @@
-"""Class for data api to extract data"""
+"""
+Class for data api to extract data
+"""
+
+# NOTE: This is deprecated class.  Use Extractor class instead
 #pylint: disable=relative-import
 
 import abc

--- a/etl_framework/BaseFilterFunctionFactory.py
+++ b/etl_framework/BaseFilterFunctionFactory.py
@@ -1,4 +1,8 @@
-"""returns filter functions for Transformer object"""
+"""
+returns filter functions for Transformer object
+"""
+
+# NOTE: This is deprecated. Use a dictionary objectinstead
 
 import abc
 

--- a/etl_framework/BaseTransformer.py
+++ b/etl_framework/BaseTransformer.py
@@ -1,6 +1,6 @@
 """Base class to transform extracted data before loading"""
 #pylint: disable=relative-import
-
+# NOTE This will be deprecated. Dont use.
 import abc
 
 from method_wrappers.check_attr_set import _check_attr_set

--- a/etl_framework/DerivedTableConfigParser.py
+++ b/etl_framework/DerivedTableConfigParser.py
@@ -4,6 +4,8 @@
 #pylint: disable=too-many-function-args
 #pylint: disable=too-many-locals
 
+# NOTE This is deprecated. Dont use
+
 from SqlSchemaConfigParser import SqlSchemaConfigParser
 
 class NoParentConfigException(Exception):

--- a/etl_framework/SourceConfigParser.py
+++ b/etl_framework/SourceConfigParser.py
@@ -1,4 +1,9 @@
-"""parses configuration and returns useful things"""
+"""
+parses configuration and returns useful things
+"""
+
+# NOTE: this is deprecated. Dont use.
+
 #pylint: disable=relative-import
 #pylint: disable=too-many-arguments
 #pylint: disable=too-many-locals

--- a/etl_framework/SqlSchemaConfigParser.py
+++ b/etl_framework/SqlSchemaConfigParser.py
@@ -1,4 +1,6 @@
 """parses configuration and can return sql schemas from configs"""
+# NOTE : This is deprecated. Dont use
+
 #pylint: disable=relative-import
 
 from SourceConfigParser import SourceConfigParser


### PR DESCRIPTION
Adds a note to advise against using deprecated classes.  These can eventually be removed once older ETLs are weened off them.