### PR TITLE
Create an entry in the etl job table if it does not yet exist

### DIFF
--- a/etl_framework/BaseEtlSetUp.py
+++ b/etl_framework/BaseEtlSetUp.py
@@ -57,6 +57,12 @@ class BaseEtlSetUp(object):
                                     ETL_JOB_WHERE_PHRASE,
                                     ])
 
+    ETL_JOB_SELECT_ALL_JOBS_STATEMENT = '\n'.join([
+                                    'SELECT',
+                                    ETL_JOBS_ID_FIELD,
+                                    'FROM {0}'.format(ETL_JOBS_TABLE),
+                                    ])
+
     ETL_JOB_SET_CUTOFF_STATEMENT = '\n'.join([
                                     ETL_JOB_UPDATE_SET_PHRASE,
                                     '\t`{0}` = {1}'.format(ETL_JOBS_CUTOFF_AT_FIELD, ETL_JOBS_STARTED_AT_FIELD),
@@ -67,6 +73,12 @@ class BaseEtlSetUp(object):
                                     ETL_JOB_UPDATE_SET_PHRASE,
                                     '\t`{0}` = \'{1}\''.format(ETL_JOBS_CUTOFF_AT_FIELD, ETL_JOB_EARLIEST_TIME),
                                     ETL_JOB_WHERE_PHRASE,
+                                    ])
+
+    ETL_JOB_CREATE_JOB_STATEMENT = '\n'.join([
+                                    'INSERT INTO {0} ({1}, {2})'.format(
+                                        ETL_JOBS_TABLE, ETL_JOBS_ID_FIELD, ETL_JOBS_NAME_FIELD),
+                                    'VALUES (%d, "%s")'
                                     ])
 
     ETL_JOB_CUTOFF_OFFSET = datetime.timedelta(days=5)
@@ -173,6 +185,7 @@ class BaseEtlSetUp(object):
         self.sql_database.set_credentials_from_dsn(self.get_bi_dsn())
 
         #set start time of etl job and get cutoff value from SQL db
+        self.create_etl_job_row_if_not_exists()
         self.run_etl_job_start_statement()
         self.set_etl_job_cutoff_value(datetime_cutoff=datetime_cutoff)
 
@@ -180,6 +193,17 @@ class BaseEtlSetUp(object):
         """do teardown for etl"""
 
         self.run_etl_job_cutoff_statement()
+
+    def create_etl_job_row_if_not_exists(self):
+        """ Inserts the requisite row into the ETL job table if it does not yet exist """
+
+        sql_statement = self.ETL_JOB_SELECT_ALL_JOBS_STATEMENT
+        job_ids = self.sql_database.run_statement(sql_statement, fetch_data=True)[0]
+        job_ids = [int(job_id[0]) for job_id in job_ids]
+
+        if self.etl_job_id not in job_ids:
+            sql_statement = self.ETL_JOB_CREATE_JOB_STATEMENT%(self.etl_job_id, self.etl_job_name, )
+            self.sql_database.run_statement(sql_statement)
 
     def set_etl_job_cutoff_value(self, datetime_cutoff=None):
         """sets etl cutoff datetime value"""


### PR DESCRIPTION
@michaelliu2 and @ianlofs 

Creates a new entry in the `_etl_jobs_` table for new etl jobs, if it does not already exist.