### PR TITLE
Hot fix

### DIFF
--- a/etl_framework/config_mixins/UpsertStatementMixin.py
+++ b/etl_framework/config_mixins/UpsertStatementMixin.py
@@ -20,7 +20,7 @@ class MySqlUpsertStatementMixin(MySqlInsertStatementMixin):
 
         coalesce_string = cls.COALESCE_MAP[coalesce]
         sql_obj = SqlClause(header='ON DUPLICATE KEY UPDATE',
-            phrases=['{} = '.format(field) + coalesce_string.format(field) for field in fields])
+            phrases=['`{}` = '.format(field) + coalesce_string.format(field) for field in fields])
 
         return sql_obj
 


### PR DESCRIPTION
@ianlofs @hdahme 

Put back ticks back into upsert statement.  It's breaking cassandra-etl

There used to be back ticks:
https://github.com/pantheon-systems/etl-framework/blob/09a98c6a7bbf48d8bc60a4d52929502794afc19b/etl_framework/config_mixins/UpsertStatementMixin.py#L22
