### PR TITLE
Field splits uses dictionary instead of list of lists

### DIFF
--- a/etl_framework/utilities/DataTraverser.py
+++ b/etl_framework/utilities/DataTraverser.py
@@ -68,18 +68,17 @@ class DataTraverser(object):
                     yield source_data[field_path[0]]
 
     @staticmethod
-    def normalize(source_data, field_paths):
+    def normalize(source_data, fields):
         """
         yields normalized data
-        field_paths : [[fieldname, [path_element1, path_element2, ...] ], ....]
+        field_paths : {[fieldname, [path_element1, path_element2, ...], ...}
         """
 
-        field_names = tuple(field_path[0] for field_path in field_paths)
-
+        field_names, field_paths = zip(*fields.iteritems())
 
         #if there are iterators that yield nothing, BadIterationException will be raised
         try:
-            field_iterators = [CyclicIterator(DataTraverser.traverse_path, source_data, path[1])
+            field_iterators = [CyclicIterator(DataTraverser.traverse_path, source_data, path)
                             for path in field_paths]
         except BadIteratorException:
             return

--- a/tests/test_data_traverser.py
+++ b/tests/test_data_traverser.py
@@ -34,60 +34,71 @@ class DataTraverserTestCases(unittest.TestCase):
                                         ]
                         }
 
-        field_paths1 = [['output_id', ['id']],
-                        ['output_id2', ['id2']]
-                        ]
+        field_paths1 = {
+            'output_id': ['id'],
+            'output_id2': ['id2']
+        }
+
         expected_output1 = [
                             {'output_id': 'id_value', 'output_id2': 'id_value2'}
                             ]
 
-        field_paths2 = [['output_id', ['id']]
-                        ]
+        field_paths2 = {
+            'output_id': ['id']
+        }
 
         expected_output2 = [
                             {'output_id': 'id_value'}
                             ]
 
-        field_paths3 = [['output_id', ['id']],
-                        ['output_name', ['names', None]]
-                        ]
+        field_paths3 = {
+            'output_id': ['id'],
+            'output_name': ['names', None]
+        }
+
         expected_output3 = [
                                 {'output_id': 'id_value', 'output_name': 'name1'},
                                 {'output_id': 'id_value', 'output_name': 'name2'},
                                 {'output_id': 'id_value', 'output_name': 'name3'}
                             ]
 
-        field_paths4 = [['output_id', ['id']],
-                        ['output_name', ['names', None]],
-                        ['output_value', ['values', None]]
-                        ]
+        field_paths4 = {
+            'output_id': ['id'],
+            'output_name': ['names', None],
+            'output_value': ['values', None]
+        }
+
         expected_output4 = [
                                 {'output_id': 'id_value', 'output_name': 'name1', 'output_value': 'value1'},
                                 {'output_id': 'id_value', 'output_name': 'name2', 'output_value': 'value2'},
                                 {'output_id': 'id_value', 'output_name': 'name3', 'output_value': 'value3'}
                             ]
 
-        field_paths5 = [['output_id', ['id']],
-                        ['output_name', ['name_values', 'name']],
-                        ['output_value', ['name_values', 'value']]
-                        ]
+        field_paths5 = {
+            'output_id': ['id'],
+            'output_name': ['name_values', 'name'],
+            'output_value': ['name_values', 'value'],
+        }
+
         expected_output5 = [
                                 {'output_id': 'id_value', 'output_name': 'name1', 'output_value': 'value1'},
                                 {'output_id': 'id_value', 'output_name': 'name2', 'output_value': 'value2'},
                                 {'output_id': 'id_value', 'output_name': 'name3', 'output_value': 'value3'}
                             ]
 
-        field_paths6 = [['output_id', ['id']],
-                        ['null_name', ['null_names_values', 'names']],
-                        ['null_value', ['null_names_values', 'values']]
-                        ]
+        field_paths6 = {
+            'output_id': ['id'],
+            'null_name': ['null_names_values', 'names'],
+            'null_value': ['null_names_values', 'values']
+        }
 
         expected_output6 = [
                             ]
 
-        field_paths7 = [['output_id', ['id']],
-                        ['null_name', ['null_names', None]]
-                        ]
+        field_paths7 = {
+            'output_id': ['id'],
+            'null_name': ['null_names', None]
+        }
 
         expected_output7 = [
                             ]


### PR DESCRIPTION
@ianlofs @hdahme When splitting fields up into 2 separate rows, we had the format

```
[
    [target_field: [path_field1, path_field2]]
]
```

Now it's

```
{
    target_field : [
       path_field1,
       path_field2
}
```

Where path_field are the sequence of fields you traverse in nested json to get to the target_field value.
